### PR TITLE
feat: add job priority preemption

### DIFF
--- a/python/ray/dashboard/modules/job/common.py
+++ b/python/ray/dashboard/modules/job/common.py
@@ -100,6 +100,8 @@ class JobInfo:
     entrypoint_memory: Optional[int] = None
     #: The quantity of various custom resources to reserve for the entrypoint command.
     entrypoint_resources: Optional[Dict[str, float]] = None
+    #: Priority for this job. Higher values indicate higher priority.
+    priority: int = 0
     #: Driver agent http address
     driver_agent_http_address: Optional[str] = None
     #: The node id that driver running on. It will be None only when the job status


### PR DESCRIPTION
## Summary
- support job priority in JobInfo and JobManager.submit_job
- preempt lower priority jobs when higher priority jobs are submitted
- add regression test for job priority preemption

## Testing
- `pre-commit run --files python/ray/dashboard/modules/job/common.py python/ray/dashboard/modules/job/job_manager.py python/ray/dashboard/modules/job/tests/test_job_manager.py` *(failed: command not found)*
- `pip install pre-commit` *(failed: No matching distribution found for pre-commit)*
- `PYTHONPATH=python pytest python/ray/dashboard/modules/job/tests/test_job_manager.py::test_priority_preemption -q` *(failed: No module named 'ray._raylet')*

------
https://chatgpt.com/codex/tasks/task_e_68a4e0c9fb488325b5fbab2c21bb7455